### PR TITLE
Allow periodic jobs to specify a closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ Sample Jenkinsfiles
 	library "kubic-jenkins-library@${env.BRANCH_NAME}"
 	coreKubicProjectPeriodic(minionCount: 50)
 
+### Example Jenkinsfile for a Periodic Kubic build with additional stages
+
+	library "kubic-jenkins-library@${env.BRANCH_NAME}"
+	coreKubicProjectPeriodic(minionCount: 50) {
+		stage('Perform Some Additional Tasks') {
+			// Add any extra step here
+		}
+	}
+
+
 Pipeline Methods
 ----------------
 

--- a/vars/coreKubicProjectPeriodic.groovy
+++ b/vars/coreKubicProjectPeriodic.groovy
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-def call(Map parameters = [:]) {
+def call(Map parameters = [:], Closure body = null) {
     int minionCount = parameters.get('minionCount')
 
     echo "Starting Kubic core project periodic"
@@ -31,8 +31,15 @@ def call(Map parameters = [:]) {
             }
         }
 
-        stage('Run Kube e2e-tests') {
-            // TODO... 
+        if (body != null) {
+            // Prepare the body closure delegate
+            def delegate = [:]
+            // Set some context variables available inside the body() method
+            delegate['environment'] = environment
+            body.delegate = delegate
+
+            // Execute the body of the test
+            body()
         }
     }
 }


### PR DESCRIPTION
This allows for multiple different periodic jobs that perform different
tasks. (e.g. variations of nightly upgrade CI jobs etc)