### PR TITLE
Increase devenv timeout to 60 mins

### DIFF
--- a/vars/createEnvironment.groovy
+++ b/vars/createEnvironment.groovy
@@ -32,9 +32,7 @@ Environment call(Map parameters = [:]) {
                 }
             }
 
-            timeout(30) {
-                sh(script: 'echo "Waiting for Velum"; until $(curl -s -k https://127.0.0.1/ | grep -q "Log in"); do echo -n "."; sleep 3; done')
-            }
+            sh(script: 'echo "Waiting for Velum"; until $(curl -s -k https://127.0.0.1/ | grep -q "Log in"); do echo -n "."; sleep 3; done')
         },
         'terraform': {
             dir('terraform') {


### PR DESCRIPTION
Devenv had a smaller timeout (30 min) than the 60 min timeout
for the whole stage. Remove the smaller timeout and allow the
outer timeout to take precedence.

The proper fix here is to add a local cache of the docker
images near the CI workers, preventing the lengthly container
image download. However, this will do for now, as timeouts in
CI are less to do with enforcing performance goals, and are
instead about making sure a CI job does not consume a CI
worker forever.