### PR TITLE
Ensure we use the devel images for CI

### DIFF
--- a/vars/createEnvironment.groovy
+++ b/vars/createEnvironment.groovy
@@ -27,6 +27,7 @@ Environment call(Map parameters = [:]) {
                     "CONTAINER_MANIFESTS_DIR=${WORKSPACE}/caasp-container-manifests/",
                     "SALT_DIR=${WORKSPACE}/salt/",
                     "VELUM_DIR=${WORKSPACE}/velum/",
+                    "STAGING=devel",
                 ]) {
                     withCredentials([
                         string(variable: 'REGISTRY_URL', credentialsId: 'caasp-docker-registry-host')
@@ -46,6 +47,7 @@ Environment call(Map parameters = [:]) {
                     "PREFIX=jenkins",
                     "WGET_FLAGS=--progress=dot:giga",
                     "NO_COLOR=true",
+                    "STAGING=devel",
                 ]) {
                     ansiColor('xterm') {
                         sh(script: 'set -o pipefail; ./contrib/libvirt/k8s-libvirt.sh apply 2>&1 | tee ${WORKSPACE}/logs/terraform-apply.log')


### PR DESCRIPTION
For both the qcow2, and docker images, we should be using the Devel
images, rather than the release images.