### PR TITLE
Replace tasks with pipeline variants

### DIFF
--- a/vars/githubCollaboratorCheck.groovy
+++ b/vars/githubCollaboratorCheck.groovy
@@ -35,7 +35,7 @@ def call(Map parameters = [:]) {
 
         } else {
             def allowExecution = input(id: 'userInput', message: "Change author is not a ${org} member: ${user}", parameters: [
-                [$class: 'BooleanParameterDefinition', defaultValue: false, description: 'Run tests anyway?', name: 'allowExecution']
+                booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
             ])
 
             if (!allowExecution) {

--- a/vars/withKubicEnvironment.groovy
+++ b/vars/withKubicEnvironment.groovy
@@ -36,7 +36,7 @@ def call(Map parameters = [:], Closure body) {
 
         // Basic prep steps
         stage('Preparation') {
-            step([$class: 'WsCleanup'])
+            cleanWs()
             sh(script: 'mkdir logs')
         }
 


### PR DESCRIPTION
Several of the $class statements we used already have pipeline
variants, without the need to construct by hand. Replace these
with the matching pipeline versions.