### PR TITLE
Allow periodic jobs to choose their node label

### DIFF
--- a/vars/coreKubicProjectPeriodic.groovy
+++ b/vars/coreKubicProjectPeriodic.groovy
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 def call(Map parameters = [:], Closure body = null) {
+    String nodeLabel = parameters.get('nodeLabel', 'leap42.3&&m1.xxlarge')
     String environmentType = parameters.get('environmentType', 'caasp-kvm')
     String openstackImage = parameters.get('openstackImage')
     int masterCount = parameters.get('masterCount', 3)
@@ -22,7 +23,7 @@ def call(Map parameters = [:], Closure body = null) {
     try {
         // TODO: Make this an OpenStack based deploy with 50+ nodes.
         withKubicEnvironment(
-                nodeLabel: 'leap42.3&&m1.xxlarge',
+                nodeLabel: nodeLabel,
                 environmentType: environmentType,
                 openstackImage: openstackImage,
                 gitBase: 'https://github.com/kubic-project',

--- a/vars/withKubicEnvironment.groovy
+++ b/vars/withKubicEnvironment.groovy
@@ -14,7 +14,7 @@
 import com.suse.kubic.Environment
 
 def call(Map parameters = [:], Closure body) {
-    def nodeLabel = parameters.get('nodeLabel', 'devel')
+    def nodeLabel = parameters.get('nodeLabel', 'leap42.3&&m1.xxlarge')
     def environmentType = parameters.get('environmentType', 'caasp-kvm')
     def openstackImage = parameters.get('openstackImage')
     def gitBase = parameters.get('gitBase')


### PR DESCRIPTION
Some periodic jobs (e.g. the OpenStack ones) don't need a large node, so
we should allow them to not ask for a large node.