### PR TITLE
coreKubicProjectCi shouldn't accept params

### DIFF
--- a/vars/coreKubicProjectCi.groovy
+++ b/vars/coreKubicProjectCi.groovy
@@ -11,11 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-def call(Map parameters = [:]) {
+def call() {
     echo "Starting Kubic core project CI"
-
-    int masterCount = parameters.get('masterCount', 3)
-    int workerCount = parameters.get('workerCount', 2)
 
     if (env.CHANGE_AUTHOR != null) {
         // TODO: Don't hardcode salt repo name, find the right place
@@ -39,8 +36,8 @@ def call(Map parameters = [:]) {
             gitBase: 'https://github.com/kubic-project',
             gitBranch: env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME),
             gitCredentialsId: 'github-token',
-            masterCount: masterCount,
-            workerCount: workerCount) {
+            masterCount: 3,
+            workerCount: 2) {
 
         stage('Run Tests') {
             // TODO: Add some cluster tests, e.g. booting pods, checking they work, etc


### PR DESCRIPTION
This is called from each projects Jenkinsfile, that file in each of the other repos
should *never* differ, they defer everything to this function, so each project is
tested in exactly the same way. This prevents 1 projects config from passing a change
that would otherwise fail with another projects config - i.e. prevents wedgeing CI.