### PR TITLE
Avoid velum update specs

### DIFF
--- a/vars/bootstrapEnvironment.groovy
+++ b/vars/bootstrapEnvironment.groovy
@@ -20,7 +20,7 @@ Environment call(Map parameters = [:]) {
 
     timeout(90) {
         dir('automation/velum-bootstrap') {
-            sh(script: 'bundle config build.nokogiri --use-system-libraries; bundle install')
+            sh(script: './velum-interactions --setup')
         }
     }
 
@@ -28,10 +28,9 @@ Environment call(Map parameters = [:]) {
         try {
             dir('automation/velum-bootstrap') {
                 withEnv([
-                    "VERBOSE=true",
                     "ENVIRONMENT=${WORKSPACE}/environment.json",
                 ]) {
-                    sh(script: "bundle exec rspec --format documentation --format RspecJunitFormatter --out velum-bootstrap.xml spec/**/*")
+                    sh(script: "./velum-interactions --configure --bootstrap")
                     sh(script: "cp kubeconfig ${WORKSPACE}/kubeconfig")
                 }
             }


### PR DESCRIPTION
With two new specs added to velum-bootstrap which we don't want to always run, we've added a script to velum-bootstrap to make selection easier.

This updates CI to use the script.

Depends-On: https://github.com/kubic-project/automation/pull/102