### PR TITLE
Refactor to allow bare metal environments

### DIFF
--- a/vars/configureEnvironment.groovy
+++ b/vars/configureEnvironment.groovy
@@ -17,7 +17,7 @@ import com.suse.kubic.Environment
 Environment call(Map parameters = [:]) {
     Environment environment = parameters.get('environment')
 
-    // TODO: This and configureEnvironment share 90% of the same code
+    // TODO: This and bootstrapEnvironment share 90% of the same code
 
     timeout(90) {
         dir('automation/velum-bootstrap') {
@@ -31,8 +31,7 @@ Environment call(Map parameters = [:]) {
                 withEnv([
                     "ENVIRONMENT=${WORKSPACE}/environment.json",
                 ]) {
-                    sh(script: "./velum-interactions --bootstrap")
-                    sh(script: "cp kubeconfig ${WORKSPACE}/kubeconfig")
+                    sh(script: "./velum-interactions --configure")
                 }
             }
         } finally {
@@ -40,7 +39,6 @@ Environment call(Map parameters = [:]) {
                 junit "velum-bootstrap.xml"
                 try {
                     archiveArtifacts(artifacts: "screenshots/**")
-                    archiveArtifacts(artifacts: "kubeconfig")
                 } catch (Exception exc) {
                     echo "Failed to Archive Artifacts"
                 }

--- a/vars/createEnvironmentWorkers.groovy
+++ b/vars/createEnvironmentWorkers.groovy
@@ -1,0 +1,32 @@
+// Copyright 2017 SUSE LINUX GmbH, Nuernberg, Germany.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import com.suse.kubic.Environment
+
+Environment call(Map parameters = [:]) {
+    Environment environment = parameters.get('environment')
+    String type = parameters.get('type', 'caasp-kvm')
+    String openstackImage = parameters.get('openstackImage')
+    int workerCount = parameters.get('workerCount')
+
+    switch (type) {
+        case 'caasp-kvm':
+            echo "Secondary worker creation step unnecessary"
+            return environment
+        case 'openstack':
+            echo "Secondary worker creation step unnecessary"
+            return environment
+        default:
+            error("Unknown environment type: ${type}")
+    }
+}

--- a/vars/withKubicEnvironment.groovy
+++ b/vars/withKubicEnvironment.groovy
@@ -59,6 +59,22 @@ def call(Map parameters = [:], Closure body) {
                 )
             }
 
+            // Configure the Kubic environment
+            stage('Configure Environment') {
+                configureEnvironment(environment: environment)
+            }
+
+            // Create Workers
+            stage('Create Environment Workers') {
+                environment = createEnvironmentWorkers(
+                    environment: environment,
+                    type: environmentType,
+                    masterCount: masterCount,
+                    workerCount: workerCount,
+                    openstackImage: openstackImage
+                )
+            }
+
             // Bootstrap the Kubic environment
             stage('Bootstrap Environment') {
                 bootstrapEnvironment(environment: environment)


### PR DESCRIPTION
Bare metal environments need to have the admin node created first, so that
the AutoYaST file is being served before creating the workers. This refactor
allows for that