### PR TITLE
Split image download into its own step

### DIFF
--- a/src/com/suse/kubic/CaaspBareMetalTypeOptions.groovy
+++ b/src/com/suse/kubic/CaaspBareMetalTypeOptions.groovy
@@ -1,0 +1,5 @@
+package com.suse.kubic;
+
+class CaaspBareMetalTypeOptions implements Serializable {
+	String image = null;
+}

--- a/src/com/suse/kubic/CaaspKvmTypeOptions.groovy
+++ b/src/com/suse/kubic/CaaspKvmTypeOptions.groovy
@@ -1,6 +1,8 @@
 package com.suse.kubic;
 
 class CaaspKvmTypeOptions implements Serializable {
+	String image = null;
+
 	int adminRam = 4096;
 	int adminCpu = 4;
 	int masterRam = 4096;

--- a/vars/createEnvironmentCaaspBareMetal.groovy
+++ b/vars/createEnvironmentCaaspBareMetal.groovy
@@ -19,30 +19,6 @@
 import com.suse.kubic.Environment
 
 Environment call(Map parameters = [:]) {
-    boolean waitISOFetching = parameters.get('waitISOFetching', true)
-
-    timeout(10) {
-        dir('automation/caasp-bare-metal/deployer') {
-            withCredentials([file(credentialsId: 'caasp-bare-metal-serverlist', variable: 'SERVERLIST_PATH'),
-                    file(credentialsId: 'caasp-bare-metal-conf', variable: 'CONFFILE')]) {
-                // Start ISO fetching
-                sh(script: 'set -o pipefail; ./deployer ${JOB_NAME}-${BUILD_NUMBER} --start-iso-fetching 2>&1 | tee ${WORKSPACE}/logs/caasp-bare-metal-start-iso-fetching.log')
-            }
-        }
-    }
-
-    if (waitISOFetching) {
-        timeout(120) {
-            dir('automation/caasp-bare-metal/deployer') {
-                withCredentials([file(credentialsId: 'caasp-bare-metal-serverlist', variable: 'SERVERLIST_PATH'),
-                        file(credentialsId: 'caasp-bare-metal-conf', variable: 'CONFFILE')]) {
-                    // Wait for ISO fetching to complete
-                    sh(script: 'set -o pipefail; ./deployer ${JOB_NAME}-${BUILD_NUMBER} --wait-iso-fetching 2>&1 | tee ${WORKSPACE}/logs/caasp-bare-metal-wait-iso-fetching.log')
-                }
-            }
-        }
-    }
-
     timeout(60) {
         dir('automation/caasp-bare-metal/deployer') {
             withCredentials([file(credentialsId: 'caasp-bare-metal-serverlist', variable: 'SERVERLIST_PATH'),
@@ -64,6 +40,5 @@ Environment call(Map parameters = [:]) {
     }
 
     // Read the generated environment file
-    Environment environment = new Environment(readJSON(file: 'environment.json'))
-    return environment
+    return new Environment(readJSON(file: 'environment.json'))
 }

--- a/vars/createEnvironmentOpenstack.groovy
+++ b/vars/createEnvironmentOpenstack.groovy
@@ -45,14 +45,7 @@ parameters:
 """)
 
             withCredentials([file(credentialsId: 'prvcld-openrc-caasp-ci-tests', variable: 'OPENRC')]) {
-                image = options.image
-
-                if (image == null || image == '') {
-                    // Find the latest Devel image if we've not been given a specific image
-                    image = sh(script: "set -o pipefail; set +x; source $OPENRC; openstack image list --property caasp-channel='devel' --property caasp-version='3.0' -c Name -f value | sort -r -V | head -n1 | tr -d \"\n\"", returnStdout: true)
-                }
-
-                sh(script: "set -o pipefail; ./caasp-openstack --openrc ${OPENRC} --heat-environment heat-environment.yaml -b -w ${workerCount} --image ${image} --name ${stackName} 2>&1 | tee ${WORKSPACE}/logs/caasp-openstack-heat-build.log")
+                sh(script: "set -o pipefail; ./caasp-openstack --openrc ${OPENRC} --heat-environment heat-environment.yaml -b -w ${workerCount} --image ${options.image} --name ${stackName} 2>&1 | tee ${WORKSPACE}/logs/caasp-openstack-heat-build.log")
             }
 
             // Read the generated environment file

--- a/vars/prepareImage.groovy
+++ b/vars/prepareImage.groovy
@@ -1,0 +1,29 @@
+// Copyright 2017 SUSE LINUX GmbH, Nuernberg, Germany.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+def call(Map parameters = [:]) {
+    String type = parameters.get('type', 'caasp-kvm')
+    def typeOptions = parameters.get('typeOptions', null)
+
+    switch (type) {
+        case 'caasp-kvm':
+            return prepareImageCaaspKvm(typeOptions: typeOptions)
+        case 'openstack':
+            return prepareImageOpenStack(typeOptions: typeOptions)
+        case 'bare-metal':
+            return prepareImageCaaspBareMetal(typeOptions: typeOptions)
+        default:
+            error("Unknown environment type: ${type}")
+    }
+}

--- a/vars/prepareImageCaaspBareMetal.groovy
+++ b/vars/prepareImageCaaspBareMetal.groovy
@@ -1,0 +1,58 @@
+// Copyright 2017 SUSE LINUX GmbH, Nuernberg, Germany.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import com.suse.kubic.CaaspBareMetalTypeOptions
+
+
+CaaspBareMetalTypeOptions call(Map parameters = [:]) {
+    CaaspBareMetalTypeOptions options = parameters.get('typeOptions', null)
+    boolean waitISOFetching = parameters.get('waitISOFetching', true)
+
+    if (options == null) {
+        options = new CaaspBareMetalTypeOptions()
+    }
+
+    if (options.image != null && options.image != '') {
+        return options
+    }
+
+    // TODO: Channel should be a param
+    String channel = "devel"
+
+    // TODO: Set the iso name into options.image - then use that as the image
+    // to deploy later in the job.
+
+    timeout(10) {
+        dir('automation/caasp-bare-metal/deployer') {
+            withCredentials([file(credentialsId: 'caasp-bare-metal-serverlist', variable: 'SERVERLIST_PATH'),
+                    file(credentialsId: 'caasp-bare-metal-conf', variable: 'CONFFILE')]) {
+                // Start ISO fetching
+                sh(script: 'set -o pipefail; ./deployer ${JOB_NAME}-${BUILD_NUMBER} --start-iso-fetching 2>&1 | tee ${WORKSPACE}/logs/caasp-bare-metal-start-iso-fetching.log')
+            }
+        }
+    }
+
+    if (waitISOFetching) {
+        timeout(120) {
+            dir('automation/caasp-bare-metal/deployer') {
+                withCredentials([file(credentialsId: 'caasp-bare-metal-serverlist', variable: 'SERVERLIST_PATH'),
+                        file(credentialsId: 'caasp-bare-metal-conf', variable: 'CONFFILE')]) {
+                    // Wait for ISO fetching to complete
+                    sh(script: 'set -o pipefail; ./deployer ${JOB_NAME}-${BUILD_NUMBER} --wait-iso-fetching 2>&1 | tee ${WORKSPACE}/logs/caasp-bare-metal-wait-iso-fetching.log')
+                }
+            }
+        }
+    }
+
+    return options
+}

--- a/vars/prepareImageOpenStack.groovy
+++ b/vars/prepareImageOpenStack.groovy
@@ -1,0 +1,38 @@
+// Copyright 2017 SUSE LINUX GmbH, Nuernberg, Germany.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import com.suse.kubic.OpenstackTypeOptions
+
+
+OpenstackTypeOptions call(Map parameters = [:]) {
+    OpenstackTypeOptions options = parameters.get('typeOptions', null)
+
+    if (options == null) {
+        options = new OpenstackTypeOptions()
+    }
+
+    if (options.image != null && options.image != '') {
+        return options
+    }
+
+    // TODO: Channel should be a param
+    String channel = "devel"
+
+    // TODO: Trigger the OpenStack Image loading job, wait for it, and use the latest image..
+    timeout(10) {
+        // Find the latest Devel image if we've not been given a specific image
+        options.image = sh(script: "set -o pipefail; set +x; source $OPENRC; openstack image list --property caasp-channel='${channel}' --property caasp-version='3.0' -c Name -f value | sort -r -V | head -n1 | tr -d \"\n\"", returnStdout: true)
+    }
+
+    return options
+}

--- a/vars/withKubicEnvironment.groovy
+++ b/vars/withKubicEnvironment.groovy
@@ -47,6 +47,14 @@ def call(Map parameters = [:], Closure body) {
             cloneAllKubicRepos(gitBase: gitBase, branch: gitBranch, credentialsId: gitCredentialsId)
         }
 
+        // Fetch the necessary images
+        stage('Retrieve Image') {
+            environmentTypeOptions = prepareImage(
+                type: environmentType,
+                typeOptions: environmentTypeOptions
+            )
+        }
+
         Environment environment;
 
         try {


### PR DESCRIPTION
The current code has been moved to prepareImage, there is still a TODO against
both openstack and bare metal, but these should be handled separately.

This allows for more easily seeing the timings for the build step, without the large
variance introduced by fetching a new image.