### PR TITLE
Revert "Set CI to use 1 master, 2 workers temporarily"

### DIFF
--- a/vars/coreKubicProjectCi.groovy
+++ b/vars/coreKubicProjectCi.groovy
@@ -36,7 +36,7 @@ def call() {
             gitBase: 'https://github.com/kubic-project',
             gitBranch: env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME),
             gitCredentialsId: 'github-token',
-            masterCount: 1,
+            masterCount: 3,
             workerCount: 2) {
 
         // Run the Core Project Tests

--- a/vars/coreKubicProjectPeriodic.groovy
+++ b/vars/coreKubicProjectPeriodic.groovy
@@ -16,7 +16,7 @@ def call(Map parameters = [:], Closure body = null) {
     String environmentType = parameters.get('environmentType', 'caasp-kvm')
     def environmentTypeOptions = parameters.get('environmentTypeOptions', null)
     boolean environmentDestroy = parameters.get('environmentDestroy', true)
-    int masterCount = parameters.get('masterCount', 1)
+    int masterCount = parameters.get('masterCount', 3)
     int workerCount = parameters.get('workerCount', 2)
 
     echo "Starting Kubic core project periodic"


### PR DESCRIPTION
This reverts commit b64ae61c05d9a1f3a12daa5c9f9e5abbdafd00c3.

Depends on: https://github.com/kubic-project/velum/pull/387
Depends on: https://github.com/kubic-project/salt/pull/314
Depends on: https://github.com/kubic-project/caasp-container-manifests/pull/134