### PR TITLE
KVM: Don't hardcode the channel name to devel

### DIFF
--- a/src/com/suse/kubic/CaaspKvmTypeOptions.groovy
+++ b/src/com/suse/kubic/CaaspKvmTypeOptions.groovy
@@ -2,6 +2,7 @@ package com.suse.kubic;
 
 class CaaspKvmTypeOptions implements Serializable {
 	String image = null;
+	String channel = 'devel';
 
 	int adminRam = 4096;
 	int adminCpu = 4;

--- a/vars/prepareImageCaaspKvm.groovy
+++ b/vars/prepareImageCaaspKvm.groovy
@@ -30,14 +30,11 @@ CaaspKvmTypeOptions call(Map parameters = [:]) {
         proxyFlag = "-P ${env.http_proxy}"
     }
 
-    // TODO: Channel should be a param
-    String channel = "devel"
-
     timeout(120) {
         dir('automation/misc-tools') {
             withCredentials([string(credentialsId: 'caasp-proxy-host', variable: 'CAASP_PROXY')]) {
-                sh(script: "set -o pipefail; ./download-image --proxy ${CAASP_PROXY} --type kvm channel://${channel} 2>&1 | tee ${WORKSPACE}/logs/caasp-kvm-prepare-image.log")
-                options.image = "file://${WORKSPACE}/automation/downloads/kvm-${channel}"
+                sh(script: "set -o pipefail; ./download-image --proxy ${CAASP_PROXY} --type kvm channel://${options.channel} 2>&1 | tee ${WORKSPACE}/logs/caasp-kvm-prepare-image.log")
+                options.image = "file://${WORKSPACE}/automation/downloads/kvm-${options.channel}"
             }
         }
     }


### PR DESCRIPTION
This allows for jobs to override the channel from devel -> release
using the CaaspKvmTypeOptions object.