### PR TITLE
[2.0] Extract Salt events from supportconfig tarballs

### DIFF
--- a/vars/gatherKubicLogs.groovy
+++ b/vars/gatherKubicLogs.groovy
@@ -39,4 +39,12 @@ def call(Map parameters = [:]) {
     timeout(30) {
         parallel(parallelSteps)
     }
+
+    // Extract failed Salt events from supportconfig tarballs, if any
+    timeout(10) {
+      sh(script: "mkdir ${WORKSPACE}/logs/supportconfig_salt_events/")
+      dir("${WORKSPACE}/logs/supportconfig_salt_events/") {
+        sh(script: "find ${WORKSPACE}/logs/ -name 'nts_*.tbz' -exec ${WORKSPACE}/automation/misc-tools/supportutils-parser -w -i {} \\;")
+      }
+    }
 }


### PR DESCRIPTION
Ignore tarballs that do not contain a salt events logfile

Backport of https://github.com/kubic-project/jenkins-library/pull/116