### PR TITLE
KVM: Add support for vanilla flag

### DIFF
--- a/src/com/suse/kubic/CaaspKvmTypeOptions.groovy
+++ b/src/com/suse/kubic/CaaspKvmTypeOptions.groovy
@@ -3,6 +3,7 @@ package com.suse.kubic;
 class CaaspKvmTypeOptions implements Serializable {
 	String image = null;
 	String channel = 'devel';
+	boolean vanilla = false;
 
 	int adminRam = 4096;
 	int adminCpu = 4;

--- a/vars/createEnvironmentCaaspKvm.groovy
+++ b/vars/createEnvironmentCaaspKvm.groovy
@@ -32,10 +32,15 @@ Environment call(Map parameters = [:]) {
         proxyFlag = "-P ${env.http_proxy}"
     }
 
+    def vanillaFlag = ""
+    if (options.vanilla) {
+        vanillaFlag = "--vanilla"
+    }
+
     timeout(120) {
         dir('automation/caasp-kvm') {
             withCredentials([string(credentialsId: 'caasp-proxy-host', variable: 'CAASP_PROXY')]) {
-                sh(script: "set -o pipefail; ./caasp-kvm -P ${CAASP_PROXY} --build -m ${masterCount} -w ${workerCount} --image ${options.image} --admin-ram ${options.adminRam} --admin-cpu ${options.adminCpu} --master-ram ${options.masterRam} --master-cpu ${options.masterCpu} --worker-ram ${options.workerRam} --worker-cpu ${options.workerCpu} 2>&1 | tee ${WORKSPACE}/logs/caasp-kvm-build.log")
+                sh(script: "set -o pipefail; ./caasp-kvm -P ${CAASP_PROXY} ${vanillaFlag} --build -m ${masterCount} -w ${workerCount} --image ${options.image} --admin-ram ${options.adminRam} --admin-cpu ${options.adminCpu} --master-ram ${options.masterRam} --master-cpu ${options.masterCpu} --worker-ram ${options.workerRam} --worker-cpu ${options.workerCpu} 2>&1 | tee ${WORKSPACE}/logs/caasp-kvm-build.log")
             }
 
             // Read the generated environment file


### PR DESCRIPTION
This will be used by the nightlys to NOT inject code into the caasp-kvm environment.