### PR TITLE
Rebase PRs prior to testing

### DIFF
--- a/vars/cloneKubicRepo.groovy
+++ b/vars/cloneKubicRepo.groovy
@@ -25,6 +25,9 @@ def call(Map parameters = [:]) {
         dir(repo) {
             if (!ignorePullRequest && env.JOB_NAME.contains(repo)) {
                 checkout scm
+
+                // Ensure the PR is rebased against the target branch
+                sh(script: "git rebase origin/${branch}")
             } else {
                 checkout([
                     $class: 'GitSCM',


### PR DESCRIPTION
Rather than forcing every PR to be manually rebased when a breaking
change lands, CI should just do it.