### PR TITLE
Download Velum image early

### DIFF
--- a/src/com/suse/kubic/CaaspKvmTypeOptions.groovy
+++ b/src/com/suse/kubic/CaaspKvmTypeOptions.groovy
@@ -2,6 +2,7 @@ package com.suse.kubic;
 
 class CaaspKvmTypeOptions implements Serializable {
 	String image = null;
+	String velumImage = null;
 	String channel = 'devel';
 	boolean vanilla = false;
 

--- a/vars/createEnvironmentCaaspKvm.groovy
+++ b/vars/createEnvironmentCaaspKvm.groovy
@@ -40,7 +40,7 @@ Environment call(Map parameters = [:]) {
     timeout(120) {
         dir('automation/caasp-kvm') {
             withCredentials([string(credentialsId: 'caasp-proxy-host', variable: 'CAASP_PROXY')]) {
-                sh(script: "set -o pipefail; ./caasp-kvm -P ${CAASP_PROXY} ${vanillaFlag} --build -m ${masterCount} -w ${workerCount} --image ${options.image} --admin-ram ${options.adminRam} --admin-cpu ${options.adminCpu} --master-ram ${options.masterRam} --master-cpu ${options.masterCpu} --worker-ram ${options.workerRam} --worker-cpu ${options.workerCpu} 2>&1 | tee ${WORKSPACE}/logs/caasp-kvm-build.log")
+                sh(script: "set -o pipefail; ./caasp-kvm -P ${CAASP_PROXY} ${vanillaFlag} --build -m ${masterCount} -w ${workerCount} --image ${options.image} --velum-image ${options.velumImage} --admin-ram ${options.adminRam} --admin-cpu ${options.adminCpu} --master-ram ${options.masterRam} --master-cpu ${options.masterCpu} --worker-ram ${options.workerRam} --worker-cpu ${options.workerCpu} 2>&1 | tee ${WORKSPACE}/logs/caasp-kvm-build.log")
             }
 
             // Read the generated environment file

--- a/vars/prepareImageCaaspKvm.groovy
+++ b/vars/prepareImageCaaspKvm.groovy
@@ -33,8 +33,14 @@ CaaspKvmTypeOptions call(Map parameters = [:]) {
     timeout(120) {
         dir('automation/misc-tools') {
             withCredentials([string(credentialsId: 'caasp-proxy-host', variable: 'CAASP_PROXY')]) {
-                sh(script: "set -o pipefail; ./download-image --proxy ${CAASP_PROXY} --type kvm channel://${options.channel} 2>&1 | tee ${WORKSPACE}/logs/caasp-kvm-prepare-image.log")
-                options.image = "file://${WORKSPACE}/automation/downloads/kvm-${options.channel}"
+                parallel 'CaaSP KVM': {
+                    sh(script: "set -o pipefail; ./download-image --proxy ${CAASP_PROXY} --type kvm channel://${options.channel} 2>&1 | tee ${WORKSPACE}/logs/caasp-kvm-prepare-image-caasp.log")
+                    options.image = "file://${WORKSPACE}/automation/downloads/kvm-${options.channel}"
+                },
+                'Velum Docker': {
+                    sh(script: "set -o pipefail; ./download-image --proxy ${CAASP_PROXY} --type docker --image-name sles12-velum-development channel://${options.channel} 2>&1 | tee ${WORKSPACE}/logs/caasp-kvm-prepare-image-velum-development.log")
+                    options.velumImage = "file://${WORKSPACE}/automation/downloads/docker-sles12-velum-development-${options.channel}"
+                }
             }
         }
     }


### PR DESCRIPTION
Download the Velum docker image early, during the "Retrieve Image" stage, in
order to keep "Create Environment" stage timings more consistent.