### PR TITLE
Use Velum image from registry.suse.de

### DIFF
--- a/vars/createEnvironmentCaaspKvm.groovy
+++ b/vars/createEnvironmentCaaspKvm.groovy
@@ -37,10 +37,15 @@ Environment call(Map parameters = [:]) {
         vanillaFlag = "--vanilla"
     }
 
+    def velumImage = "channel://${options.channel}"
+    if (options.velumImage) {
+        velumImage = "${options.velumImage}"
+    }
+
     timeout(120) {
         dir('automation/caasp-kvm') {
             withCredentials([string(credentialsId: 'caasp-proxy-host', variable: 'CAASP_PROXY')]) {
-                sh(script: "set -o pipefail; ./caasp-kvm -P ${CAASP_PROXY} ${vanillaFlag} --build --disable-meltdown-spectre-fixes -m ${masterCount} -w ${workerCount} --image ${options.image} --velum-image ${options.velumImage} --admin-ram ${options.adminRam} --admin-cpu ${options.adminCpu} --master-ram ${options.masterRam} --master-cpu ${options.masterCpu} --worker-ram ${options.workerRam} --worker-cpu ${options.workerCpu} 2>&1 | tee ${WORKSPACE}/logs/caasp-kvm-build.log")
+                sh(script: "set -o pipefail; ./caasp-kvm -P ${CAASP_PROXY} ${vanillaFlag} --build --disable-meltdown-spectre-fixes -m ${masterCount} -w ${workerCount} --image ${options.image} --velum-image ${velumImage} --admin-ram ${options.adminRam} --admin-cpu ${options.adminCpu} --master-ram ${options.masterRam} --master-cpu ${options.masterCpu} --worker-ram ${options.workerRam} --worker-cpu ${options.workerCpu} 2>&1 | tee ${WORKSPACE}/logs/caasp-kvm-build.log")
             }
 
             // Read the generated environment file

--- a/vars/prepareImageCaaspKvm.groovy
+++ b/vars/prepareImageCaaspKvm.groovy
@@ -36,10 +36,6 @@ CaaspKvmTypeOptions call(Map parameters = [:]) {
                 parallel 'CaaSP KVM': {
                     sh(script: "set -o pipefail; ./download-image --proxy ${CAASP_PROXY} --type kvm channel://${options.channel} 2>&1 | tee ${WORKSPACE}/logs/caasp-kvm-prepare-image-caasp.log")
                     options.image = "file://${WORKSPACE}/automation/downloads/kvm-${options.channel}"
-                },
-                'Velum Docker': {
-                    sh(script: "set -o pipefail; ./download-image --proxy ${CAASP_PROXY} --type docker --image-name sles12-velum-development channel://${options.channel} 2>&1 | tee ${WORKSPACE}/logs/caasp-kvm-prepare-image-velum-development.log")
-                    options.velumImage = "file://${WORKSPACE}/automation/downloads/docker-sles12-velum-development-${options.channel}"
                 }
             }
         }


### PR DESCRIPTION
This is not an ideal change, as we no longer separate the image pull from the
rebuild. Given how slow the Provo connection to Nue can be, this may become
a problem.

For now, lets give it a shot so the Build Service team can revert the temporary
change they have applied for us.