### PR TITLE
Remove unused argument `--no-tty` from the conformance tests call

### DIFF
--- a/vars/runTestK8sConformance.groovy
+++ b/vars/runTestK8sConformance.groovy
@@ -17,11 +17,11 @@ def call(Map parameters = [:]) {
         try {
             timeout(2 * 60 * 60) {
                 ansiColor {
-                    sh(script: "./e2e-tests --no-tty --kubeconfig ${WORKSPACE}/kubeconfig --artifacts report --log ${WORKSPACE}/logs/k8s-e2e-tests.log")
+                    sh(script: "./e2e-tests --kubeconfig ${WORKSPACE}/kubeconfig --artifacts report --log ${WORKSPACE}/logs/k8s-e2e-tests.log")
                 }
             }
         } finally {
-            junit("report/*.xml")
+            junit("report/plugins/e2e/results/*.xml")
         }
     }
 }


### PR DESCRIPTION
Depends on: https://github.com/kubic-project/automation/pull/272