### PR TITLE
Upgrade to Helm 2.8.2 + Add Helm Test step

### DIFF
--- a/vars/coreKubicProjectTests.groovy
+++ b/vars/coreKubicProjectTests.groovy
@@ -54,7 +54,10 @@ def call(Map parameters = [:]) {
                 ]
             )
 
-            // TODO: Test if MariaDB is up and reachable and...
+            helmTestRelease(
+                environment: environment,
+                releaseName: releaseName
+            )
 
             helmDeleteRelease(
                 environment: environment,

--- a/vars/helmInstallChart.groovy
+++ b/vars/helmInstallChart.groovy
@@ -33,7 +33,11 @@ def call(Map parameters = [:]) {
     archiveArtifacts(artifacts: "helm-values-${safeChartName}-${releaseName}.yaml", fingerprint: true)
 
     withEnv(["KUBECONFIG=${WORKSPACE}/kubeconfig"]) {
-        sh(script: "set -o pipefail; ${WORKSPACE}/helm --home ${WORKSPACE}/.helm install ${chartName} ${waitFlag} --name ${releaseName} --values helm-values-${safeChartName}-${releaseName}.yaml 2>&1 | tee ${WORKSPACE}/logs/helm-install-${releaseName}-${safeChartName}.log")
+        sh(script: "set -o pipefail; ${WORKSPACE}/helm --home ${WORKSPACE}/.helm install ${chartName} ${waitFlag} --namespace ${releaseName} --name ${releaseName} --values helm-values-${safeChartName}-${releaseName}.yaml 2>&1 | tee ${WORKSPACE}/logs/helm-install-${releaseName}-${safeChartName}.log")
+    }
+
+    if (wait) {
+        sh(script: "${WORKSPACE}/automation/misc-tools/verify-pods-in-ns.sh ${WORKSPACE}/kubeconfig ${releaseName}")
     }
 
     return releaseName

--- a/vars/helmInstallClient.groovy
+++ b/vars/helmInstallClient.groovy
@@ -17,7 +17,7 @@ def call() {
     lock("helm-install-client") {
         // This whole thing is a hack, we should be using our builds of the
         // helm client.
-        sh(script: "wget -O /tmp/helm.tar.gz https://kubernetes-helm.storage.googleapis.com/helm-v2.7.2-linux-amd64.tar.gz")
+        sh(script: "wget -O /tmp/helm.tar.gz https://kubernetes-helm.storage.googleapis.com/helm-v2.8.2-linux-amd64.tar.gz")
         sh(script: "tar --directory /tmp -xzvf /tmp/helm.tar.gz")
         sh(script: "mv /tmp/linux-amd64/helm ${WORKSPACE}/helm")
         sh(script: "${WORKSPACE}/helm --home ${WORKSPACE}/.helm init --client-only")

--- a/vars/helmTestRelease.groovy
+++ b/vars/helmTestRelease.groovy
@@ -1,0 +1,32 @@
+// Copyright 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import com.suse.kubic.Environment
+
+def call(Map parameters = [:]) {
+    Environment environment = parameters.get('environment')
+    String releaseName = parameters.get('releaseName')
+    boolean cleanup = parameters.get('cleanup', true)
+    int timeout = parameters.get('timeout', 600)
+
+    echo "Testing Helm release: ${releaseName}"
+
+    String cleanupFlag = ""
+    if (cleanup) {
+        cleanupFlag = "--cleanup"
+    }
+
+    withEnv(["KUBECONFIG=${WORKSPACE}/kubeconfig"]) {
+        sh(script: "set -o pipefail; ${WORKSPACE}/helm --home ${WORKSPACE}/.helm test ${cleanupFlag} --timeout ${timeout} ${releaseName} 2>&1 | tee ${WORKSPACE}/logs/helm-test-${releaseName}.log")
+    }
+}


### PR DESCRIPTION
Helm 2.8.2 fixes an issue with --wait, among other compatibility fixes,
allowing us to now use the `helm test` command.