### PR TITLE
Helm Tests: Don't cleanup test pods by default

### DIFF
--- a/vars/helmDeleteRelease.groovy
+++ b/vars/helmDeleteRelease.groovy
@@ -27,5 +27,6 @@ def call(Map parameters = [:]) {
 
     withEnv(["KUBECONFIG=${WORKSPACE}/kubeconfig"]) {
         sh(script: "set -o pipefail; ${WORKSPACE}/helm --home ${WORKSPACE}/.helm delete ${purgeFlag} ${releaseName} 2>&1 | tee ${WORKSPACE}/logs/helm-delete-${releaseName}.log")
+        sh(script: "set -o pipefail; kubectl delete namespace ${releaseName} 2>&1 | tee -a ${WORKSPACE}/logs/helm-delete-${releaseName}.log")
     }
 }

--- a/vars/helmTestRelease.groovy
+++ b/vars/helmTestRelease.groovy
@@ -16,7 +16,7 @@ import com.suse.kubic.Environment
 def call(Map parameters = [:]) {
     Environment environment = parameters.get('environment')
     String releaseName = parameters.get('releaseName')
-    boolean cleanup = parameters.get('cleanup', true)
+    boolean cleanup = parameters.get('cleanup', false)
     int timeout = parameters.get('timeout', 600)
 
     echo "Testing Helm release: ${releaseName}"


### PR DESCRIPTION
Cleaning up test pods means we destroy the logs we need to gather in order
to debug.