### PR TITLE
Ensure we correctly handle the now mutable environment object

### DIFF
--- a/vars/addNode.groovy
+++ b/vars/addNode.groovy
@@ -21,10 +21,15 @@ Environment call(Map parameters = [:]) {
     Environment environment = parameters.get('environment')
 
     timeout(125) {
-        dir('automation/velum-bootstrap') {
-            try {
-                sh(script: './velum-interactions --node-add')
-            } finally {
+        try {
+            dir('automation/velum-bootstrap') {
+                sh(script: './velum-interactions --node-add --environment ${WORKSPACE}/environment.json')
+            }
+
+            // Read the updated environment file
+            environment = new Environment(readJSON(file: 'environment.json'))
+        } finally {
+            dir('automation/velum-bootstrap') {
                 junit "velum-bootstrap.xml"
                 try {
                     archiveArtifacts(artifacts: "screenshots/**")
@@ -35,4 +40,6 @@ Environment call(Map parameters = [:]) {
             }
         }
     }
+
+    return environment
 }

--- a/vars/bootstrapEnvironment.groovy
+++ b/vars/bootstrapEnvironment.groovy
@@ -31,6 +31,9 @@ Environment call(Map parameters = [:]) {
                 sh(script: "./velum-interactions --bootstrap --download-kubeconfig --enable-tiller --environment ${WORKSPACE}/environment.json")
                 sh(script: "cp kubeconfig ${WORKSPACE}/kubeconfig")
             }
+
+            // Read the updated environment file
+            environment = new Environment(readJSON(file: 'environment.json'))
         } finally {
             dir('automation/velum-bootstrap') {
                 junit "velum-bootstrap.xml"
@@ -43,4 +46,6 @@ Environment call(Map parameters = [:]) {
             }
         }
     }
+
+    return environment
 }

--- a/vars/coreKubicProjectPeriodic.groovy
+++ b/vars/coreKubicProjectPeriodic.groovy
@@ -52,8 +52,15 @@ def call(Map parameters = [:], Closure preBootstrapBody = null, Closure body = n
                 body.delegate = delegate
 
                 // Execute the body of the test
-                body()
+                def bodyResult = body()
+                if (bodyResult instanceof Environment) {
+                    // TODO: Update closures to always return the environment, to
+                    // handle cases where the closure modify the environment.
+                    environment = bodyResult
+                }
             }
+
+            return environment
         }
     } catch (e) {
         echo "Sending failure notification"

--- a/vars/removeNode.groovy
+++ b/vars/removeNode.groovy
@@ -22,8 +22,11 @@ Environment call(Map parameters = [:]) {
     timeout(125) {
         try {
             dir('automation/velum-bootstrap') {
-                sh(script: './velum-interactions --node-remove')
+                sh(script: './velum-interactions --node-remove --environment ${WORKSPACE}/environment.json')
             }
+
+            // Read the updated environment file
+            environment = new Environment(readJSON(file: 'environment.json'))
         } finally {
             dir('automation/velum-bootstrap') {
                 junit "velum-bootstrap.xml"
@@ -36,4 +39,6 @@ Environment call(Map parameters = [:]) {
             }
         }
     }
+
+    return environment
 }

--- a/vars/withKubicEnvironment.groovy
+++ b/vars/withKubicEnvironment.groovy
@@ -81,7 +81,12 @@ def call(Map parameters = [:], Closure preBootstrapBody = null, Closure body) {
                 preBootstrapBody.delegate = delegate
 
                 // Execute the preBootstrapBody of the test
-                preBootstrapBody()
+                def preBootstrapBodyResult = preBootstrapBody()
+                if (preBootstrapBodyResult instanceof Environment) {
+                    // TODO: Update closures to always return the environment, to
+                    // handle cases where the closure modify the environment.
+                    environment = preBootstrapBodyResult
+                }
             }
 
             // Configure the Kubic environment
@@ -103,7 +108,7 @@ def call(Map parameters = [:], Closure preBootstrapBody = null, Closure body) {
             // Bootstrap the Kubic environment
             // and fetch ${WORKSPACE}/kubeconfig
             stage('Bootstrap Environment') {
-                bootstrapEnvironment(environment: environment)
+                environment = bootstrapEnvironment(environment: environment)
             }
 
             // Prepare the body closure delegate
@@ -114,7 +119,12 @@ def call(Map parameters = [:], Closure preBootstrapBody = null, Closure body) {
             body.delegate = delegate
 
             // Execute the body of the test
-            body()
+            def bodyResult = body()
+            if (bodyResult instanceof Environment) {
+                // TODO: Update closures to always return the environment, to
+                // handle cases where the closure modify the environment.
+                environment = bodyResult
+            }
         } finally {
             // Gather logs from the environment
             stage('Gather Logs') {


### PR DESCRIPTION
Now that the environment is mutable, we need to ensure we re-read the
updated environment.json file, as well as return the environment through
any closures that may modify the environment.