### PR TITLE
make caaspkvm timeout configurable

### DIFF
--- a/src/com/suse/kubic/CaaspKvmTypeOptions.groovy
+++ b/src/com/suse/kubic/CaaspKvmTypeOptions.groovy
@@ -7,6 +7,7 @@ class CaaspKvmTypeOptions implements Serializable {
 	boolean vanilla = false;
 	String extraRepo = null;
 	boolean disableMeltdownSpectreFixes = true;
+	int timeout = 45;
 
 	int adminRam = 4096;
 	int adminCpu = 4;

--- a/vars/createEnvironmentCaaspKvm.groovy
+++ b/vars/createEnvironmentCaaspKvm.groovy
@@ -52,7 +52,7 @@ Environment call(Map parameters = [:]) {
         extraRepo = "--extra-repo ${options.extraRepo}"
     }
 
-    timeout(45) {
+    timeout(options.timeout) {
         dir('automation/caasp-kvm') {
             try {
                 withCredentials([


### PR DESCRIPTION
specifically in the sandbox job, which is triggered manually on demand
the download of the image, which is not cached can take much longer than
45min

Signed-off-by: Maximilian Meister <mmeister@suse.de>