### PR TITLE
During gatherKubicLogs pull salt events directly

### DIFF
--- a/vars/gatherKubicLogs.groovy
+++ b/vars/gatherKubicLogs.groovy
@@ -44,7 +44,8 @@ def call(Map parameters = [:]) {
     timeout(10) {
       sh(script: "mkdir ${WORKSPACE}/logs/supportconfig_salt_events/")
       dir("${WORKSPACE}/logs/supportconfig_salt_events/") {
-        sh(script: "find ${WORKSPACE}/logs/ -name 'nts_*.tbz' -exec ${WORKSPACE}/automation/misc-tools/supportutils-parser -w -i {} \\;")
+        sh(script: "find ${WORKSPACE}/logs/ -name 'nts_*.tbz' -print0 | xargs -I ! -0 sh -c 'export F=\"!\"; tar -Oxf \$F */salt-events-summary.txt > \"\${F%%tbz}salt_failures.txt\"'")
+        sh(script: "find ${WORKSPACE}/logs/ -name 'nts_*.tbz' -print0 | xargs -I ! -0 sh -c 'export F=\"!\"; tar -Oxf \$F */salt-events.json > \"\${F%%tbz}salt_failures_full.json\"'")
       }
     }
 }


### PR DESCRIPTION
Updated the gatherKubicLogs step to pull the newly created velum-salt-events-summary.txt and velum-salt-events.yml files directly from the tbz files generated from supportconfig.

No longer running supportutils-parser on the velum-salt-events.yml because the summary file already contains preprocessed clean output.

The new summary is placed in the same file that supportutils-parser wrote previously, [tbz_filename].salt_failures.txt

The full detail in JSON format is placed in [tbz_filename].salt_failures_full.yml