### PR TITLE
Include build URL when marking workers offline

### DIFF
--- a/vars/offlineJenkinsSlave.groovy
+++ b/vars/offlineJenkinsSlave.groovy
@@ -30,7 +30,7 @@ def call(Map parameters = [:]) {
         } else {
             echo "Marking build slave as online"
         }
-        
+
         computer.setTemporarilyOffline(offline, new OfflineCause.ByCLI(message))
     }
 }

--- a/vars/withKubicEnvironment.groovy
+++ b/vars/withKubicEnvironment.groovy
@@ -161,7 +161,7 @@ def call(Map parameters = [:], Closure preBootstrapBody = null, Closure body) {
                     }
                 } else {
                     echo "Skipping Destroy Environment as requested"
-                    offlineJenkinsSlave()
+                    offlineJenkinsSlave(message: "Marked offline by ${env.BUILD_URL}")
                 }
             }
 


### PR DESCRIPTION
Help tracking why and when a worker was marked offline.