### PR TITLE
Redownload kubeconfig after upgrade jobs

### DIFF
--- a/vars/upgradeEnvironment.groovy
+++ b/vars/upgradeEnvironment.groovy
@@ -46,12 +46,17 @@ Environment call(Map parameters = [:]) {
                 dir('automation/velum-bootstrap') {
                     sh(script: "./velum-interactions --update-admin --environment ${WORKSPACE}/environment.json")
                     sh(script: "./velum-interactions --update-minions --environment ${WORKSPACE}/environment.json")
+                    sh(script: "./velum-interactions --download-kubeconfig --environment ${WORKSPACE}/environment.json")
+                    sh(script: "mv ${WORKSPACE}/kubeconfig ${WORKSPACE}/kubeconfig.old")
+                    sh(script: "cp kubeconfig ${WORKSPACE}/kubeconfig")
+                    sh(script: "diff -u ${WORKSPACE}/kubeconfig.old ${WORKSPACE}/kubeconfig || :")
                 }
             } finally {
                 dir('automation/velum-bootstrap') {
                     junit "velum-bootstrap.xml"
                     try {
                         archiveArtifacts(artifacts: "screenshots/**")
+                        archiveArtifacts(artifacts: "kubeconfig")
                     } catch (Exception exc) {
                         echo "Failed to Archive Artifacts"
                     }


### PR DESCRIPTION
When upgrading from 2.x to 3.x, we've bumped the version of Dex we include. This update renders all "old" kubeconfig files invalid, and users must re-download updated kubeconfig.

By redownloading the kubeconfig file, we'll allow the 2.x -> 3.x upgrade CI jobs to proceed further. 