### PR TITLE
Fix salt event extraction

### DIFF
--- a/vars/gatherKubicLogs.groovy
+++ b/vars/gatherKubicLogs.groovy
@@ -42,10 +42,8 @@ def call(Map parameters = [:]) {
 
     // Extract failed Salt events from supportconfig tarballs, if any
     timeout(10) {
-      sh(script: "mkdir ${WORKSPACE}/logs/supportconfig_salt_events/")
-      dir("${WORKSPACE}/logs/supportconfig_salt_events/") {
-        sh(script: "find ${WORKSPACE}/logs/ -name 'nts_*.tbz' -print0 | xargs -I ! -0 sh -c 'export F=\"!\"; tar -Oxf \$F */salt-events-summary.txt > \"\${F%%tbz}salt_failures.txt\"'")
-        sh(script: "find ${WORKSPACE}/logs/ -name 'nts_*.tbz' -print0 | xargs -I ! -0 sh -c 'export F=\"!\"; tar -Oxf \$F */salt-events.json > \"\${F%%tbz}salt_failures_full.json\"'")
+      dir("${WORKSPACE}/logs") {
+        sh(script: "find . -name 'nts_*.tbz' -print0 | xargs -I ! -0 tar --wildcards --strip-components=1 -xf ! */salt-events.json */salt-events-summary.txt")
       }
     }
 }


### PR DESCRIPTION
Without --wildcards, the events would not be extracted. Additionally,
simplify the extraction commands and prevent the creation of unnecessary
events files for tarballs which don't contain the salt events.