### PR TITLE
Split upgradeEnvironment into 2 stages

### DIFF
--- a/vars/coreKubicProjectCi.groovy
+++ b/vars/coreKubicProjectCi.groovy
@@ -44,9 +44,13 @@ def call() {
         )
 
         // Run through the upgrade orchestration
-        upgradeEnvironment(
+        upgradeEnvironmentStage1(
             environment: environment,
             fakeUpdatesAvailable: true
+        )
+
+        upgradeEnvironmentStage2(
+            environment: environment
         )
 
         // Run the Core Project Tests again

--- a/vars/upgradeEnvironmentStage1.groovy
+++ b/vars/upgradeEnvironmentStage1.groovy
@@ -1,0 +1,64 @@
+// Copyright 2017 SUSE LINUX GmbH, Nuernberg, Germany.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import com.suse.kubic.Environment
+import com.suse.kubic.Minion
+
+// Upgrade Stage 1 - Performs remaining upgrade steps using the "old"
+// version of the automation tools.
+
+Environment call(Map parameters = [:]) {
+    Environment environment = parameters.get('environment')
+    boolean fakeUpdatesAvailable = parameters.get('fakeUpdatesAvailable', false)
+
+    // Find the admin minion
+    Minion adminMinion = null
+
+    environment.minions.each { minion ->
+        if (minion.role == "admin") {
+            adminMinion = minion
+        }
+    }
+
+    stage('Upgrade Environment 1') {
+        if (fakeUpdatesAvailable) {
+            // Fake the need for updates
+            shOnMinion(
+                minion: adminMinion,
+                script: "docker exec -i \\\$(docker ps | grep salt-master | awk '{print \\\$1}') salt '*' grains.setval tx_update_reboot_needed true"
+            )
+        }
+
+        // Refresh Salt Grains (we could wait 10 mins, but that's 10 minutes wasted in CI)
+        shOnMinion(minion: adminMinion, script: "docker exec -i \\\$(docker ps | grep salt-master | awk '{print \\\$1}') salt '*' saltutil.refresh_grains")
+
+        // Perform the upgrade
+        timeout(185) {
+            try {
+                dir('automation/velum-bootstrap') {
+                    sh(script: "./velum-interactions --update-admin --environment ${WORKSPACE}/environment.json")
+                }
+            } finally {
+                dir('automation/velum-bootstrap') {
+                    junit "velum-bootstrap.xml"
+                    try {
+                        archiveArtifacts(artifacts: "screenshots/**")
+                        archiveArtifacts(artifacts: "kubeconfig")
+                    } catch (Exception exc) {
+                        echo "Failed to Archive Artifacts"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vars/upgradeEnvironmentStage2.groovy
+++ b/vars/upgradeEnvironmentStage2.groovy
@@ -14,37 +14,17 @@
 import com.suse.kubic.Environment
 import com.suse.kubic.Minion
 
+// Upgrade Stage 2 - Performs remaining upgrade steps using the "new"
+// version of the automation tools.
 
 Environment call(Map parameters = [:]) {
     Environment environment = parameters.get('environment')
-    boolean fakeUpdatesAvailable = parameters.get('fakeUpdatesAvailable', false)
-
-    // Find the admin minion
-    Minion adminMinion = null
-
-    environment.minions.each { minion ->
-        if (minion.role == "admin") {
-            adminMinion = minion
-        }
-    }
-
-    stage('Upgrade Environment') {
-        if (fakeUpdatesAvailable) {
-            // Fake the need for updates
-            shOnMinion(
-                minion: adminMinion,
-                script: "docker exec -i \\\$(docker ps | grep salt-master | awk '{print \\\$1}') salt '*' grains.setval tx_update_reboot_needed true"
-            )
-        }
-
-        // Refresh Salt Grains (we could wait 10 mins, but that's 10 minutes wasted in CI)
-        shOnMinion(minion: adminMinion, script: "docker exec -i \\\$(docker ps | grep salt-master | awk '{print \\\$1}') salt '*' saltutil.refresh_grains")
-
+    
+    stage('Upgrade Environment 2') {
         // Perform the upgrade
         timeout(185) {
             try {
                 dir('automation/velum-bootstrap') {
-                    sh(script: "./velum-interactions --update-admin --environment ${WORKSPACE}/environment.json")
                     sh(script: "./velum-interactions --update-minions --environment ${WORKSPACE}/environment.json")
                     sh(script: "./velum-interactions --download-kubeconfig --environment ${WORKSPACE}/environment.json")
                     sh(script: "mv ${WORKSPACE}/kubeconfig ${WORKSPACE}/kubeconfig.old")


### PR DESCRIPTION
This allows for upgrade tests to change the automation branch after
it has updated the admin node. This is needed older automation tools
may not be compatible with the newer velum etc.

Backport of https://github.com/kubic-project/jenkins-library/pull/193