### PR TITLE
Move nightly jobs to jenkins.dedicated workers

### DIFF
--- a/vars/coreKubicProjectPeriodic.groovy
+++ b/vars/coreKubicProjectPeriodic.groovy
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 def call(Map parameters = [:], Closure preBootstrapBody = null, Closure body = null) {
-    String nodeLabel = parameters.get('nodeLabel', 'leap42.3&&32GB')
+    String nodeLabel = parameters.get('nodeLabel', 'leap42.3&&jenkins.dedicated')
     String environmentType = parameters.get('environmentType', 'caasp-kvm')
     def environmentTypeOptions = parameters.get('environmentTypeOptions', null)
     boolean environmentDestroy = parameters.get('environmentDestroy', true)


### PR DESCRIPTION
This worker type has significantly more resources and is in a dedicated
host aggregate within out OpenStack cloud.