### PR TITLE
Update Jenkins NodeLabels

### DIFF
--- a/vars/coreKubicProjectCi.groovy
+++ b/vars/coreKubicProjectCi.groovy
@@ -29,7 +29,7 @@ def call() {
     ])
 
     withKubicEnvironment(
-            nodeLabel: 'leap42.3&&32GB',
+            nodeLabel: 'leap42.3&&caasp-pr-worker',
             environmentType: 'caasp-kvm',
             gitBase: 'https://github.com/kubic-project',
             gitBranch: env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME),

--- a/vars/coreKubicProjectPeriodic.groovy
+++ b/vars/coreKubicProjectPeriodic.groovy
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 def call(Map parameters = [:], Closure preBootstrapBody = null, Closure body = null) {
-    String nodeLabel = parameters.get('nodeLabel', 'leap42.3&&jenkins.dedicated')
+    String nodeLabel = parameters.get('nodeLabel', 'leap42.3&&caasp-nightly-worker')
     String environmentType = parameters.get('environmentType', 'caasp-kvm')
     def environmentTypeOptions = parameters.get('environmentTypeOptions', null)
     boolean environmentDestroy = parameters.get('environmentDestroy', true)

--- a/vars/withKubicEnvironment.groovy
+++ b/vars/withKubicEnvironment.groovy
@@ -14,7 +14,7 @@
 import com.suse.kubic.Environment
 
 def call(Map parameters = [:], Closure preBootstrapBody = null, Closure body) {
-    def nodeLabel = parameters.get('nodeLabel', 'leap42.3&&32GB')
+    def nodeLabel = parameters.get('nodeLabel', 'leap42.3&&caasp-pr-worker')
     def environmentType = parameters.get('environmentType', 'caasp-kvm')
     def environmentTypeOptions = parameters.get('environmentTypeOptions', null)
     boolean environmentDestroy = parameters.get('environmentDestroy', true)


### PR DESCRIPTION
Updates the default nodelabels to be slightly more generic, which will also move the PR jobs onto a new larger worker size.