### PR TITLE
Add configuration options for `coreKubicProjectCi`

### DIFF
--- a/vars/coreKubicProjectCi.groovy
+++ b/vars/coreKubicProjectCi.groovy
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-def call() {
+def call(Map params = [:]) {
     echo "Starting Kubic core project CI"
-
     // TODO: Don't hardcode salt repo name, find the right place
     // to lookup this information dynamically.
     githubCollaboratorCheck(
@@ -27,19 +26,29 @@ def call() {
         buildDiscarder(logRotator(numToKeepStr: '15')),
         disableConcurrentBuilds(),
         parameters([
-            booleanParam(name: 'ENVIRONMENT_DESTROY', defaultValue: true, description: 'Destroy env once done?')
+            booleanParam(name: 'ENVIRONMENT_DESTROY', defaultValue: true, description: 'Destroy env once done?'),
+            // Could use validatingString to check for integer
+            string(name: 'MASTER_COUNT', defaultValue: "3", description: 'Number of masters to start.'),
+            string(name: 'WORKER_COUNT', defaultValue: "2", description: 'Number of workers to start.')
         ]),
     ])
+    environment = env.getEnvironment()
+    // The environmentTypeOptions are structs and can not easily be entered in the web ui. So instead of obtaining them from there, they will be passed as parameters directly.
+    def environmentTypeOptions = params.get('environmentTypeOptions', null)
+    boolean environmentDestroy = environment.get('ENVIRONMENT_DESTROY', 'true').toBoolean()
+    int masterCount = environment.get('MASTER_COUNT', "3").toInteger()
+    int workerCount = environment.get('WORKER_COUNT', "2").toInteger()
 
     withKubicEnvironment(
             nodeLabel: 'leap15.0&&caasp-pr-worker',
             environmentType: 'caasp-kvm',
-            environmentDestroy: env.getEnvironment().get('ENVIRONMENT_DESTROY', 'true').toBoolean(),
+            environmentTypeOptions: environmentTypeOptions,
+            environmentDestroy: environmentDestroy,
             gitBase: 'https://github.com/kubic-project',
             gitBranch: env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME),
             gitCredentialsId: 'github-token',
-            masterCount: 3,
-            workerCount: 2) {
+            masterCount: masterCount,
+            workerCount: workerCount) {
 
         // Run the Core Project Tests
         coreKubicProjectTests(


### PR DESCRIPTION
Allow configuring number of masters & workers via the environment.

Also allow passing additional configuration for the environmentType as
a parameter.

This mostly attempts to introduce the configurability from `periodic` builds
to the `core` build to make testing new pipelines easier.