### PR TITLE
use E2E_WAIT_TIME to set timeout instead of hard coded value

### DIFF
--- a/vars/runK8sE2eTests.groovy
+++ b/vars/runK8sE2eTests.groovy
@@ -26,7 +26,7 @@ def call(Map parameters = [:]) {
 
     dir("${WORKSPACE}/automation/k8s-e2e-tests") {
         try {
-            timeout(180) {
+            timeout(env.getEnvironment().get('E2E_WAIT_TIME', '180').toInteger()) {
                 ansiColor {
                     sh(script: e2eCmd)
                 }


### PR DESCRIPTION
The default time out of 3 hours isn't long enough for some of the e2e tests. This makes it so that if the E2E_WAIT_TIME  env variable is set for the e2e test script then it sets it for the Jenkins timeout as well