### PR TITLE
vars: withKubicEnvironment: Sort 'env' output

### DIFF
--- a/vars/withKubicEnvironment.groovy
+++ b/vars/withKubicEnvironment.groovy
@@ -35,7 +35,7 @@ def call(Map parameters = [:], Closure preBootstrapBody = null, Closure body) {
         stage('Node Info') {
             echo "Node: ${env.NODE_NAME}"
             echo "Workspace: ${env.WORKSPACE}"
-            sh(script: 'env')
+            sh(script: 'env | sort')
             sh(script: 'ip a')
             sh(script: 'ip r')
             sh(script: 'cat /etc/resolv.conf')


### PR DESCRIPTION
Keep the 'env' output sorted so we can quickly check the status of an
env variable.