### PR TITLE
vars: runTestInfra: Collect cluster-info file

### DIFF
--- a/vars/runTestInfra.groovy
+++ b/vars/runTestInfra.groovy
@@ -35,6 +35,12 @@ def call(Map parameters = [:]) {
                         }
                     } finally {
                         junit "testinfra-${minion.role}-${minion.index}.xml"
+                        try {
+                            sh("set -o pipefail; ls -R /tmp;  cp /tmp/cluster_info/nodes.json nodes.json")
+                            archiveArtifacts(artifacts: "nodes.json")
+                        } catch (Exception exc) {
+                            echo "Failed to Archive Artifacts"
+                        }
                     }
                 }
 


### PR DESCRIPTION
testinfra tests some times are failing when reading the cluster-info
file so we need to collect it in order to be able to find out what's
wrong.