### PR TITLE
[3.0] Allow to choose sonobuoy image and version as Jenkins build parameters

### DIFF
--- a/vars/runTestK8sConformance.groovy
+++ b/vars/runTestK8sConformance.groovy
@@ -13,11 +13,27 @@
 // limitations under the License.
 
 def call(Map parameters = [:]) {
+    def e2eFocus = parameters.get('e2eFocus', null)
+    def e2eSkip = parameters.get('e2eSkip', null)
+    def sonobuoyImage = parameters.get('sonobuoyImage', 'gcr.io/heptio-images/sonobuoy')
+    def sonobuoyVersion = parameters.get('sonobuoyVersion', 'latest')
+    def e2eCmd = "./e2e-tests --kubeconfig ${WORKSPACE}/kubeconfig"
+
+    if (e2eFocus != null) {
+        e2eCmd += " --e2e-focus '${e2eFocus}'"
+    }
+    if (e2eSkip != null) {
+        e2eCmd += " --e2e-skip '${e2eSkip}'"
+    }
+
+    e2eCmd += " --sonobuoy-image '${sonobuoyImage}'"
+    e2eCmd += " --sonobuoy-version '${sonobuoyVersion}'"
+
     dir("${WORKSPACE}/automation/k8s-e2e-tests") {
         try {
             timeout(180) {
                 ansiColor {
-                    sh(script: "./e2e-tests --kubeconfig ${WORKSPACE}/kubeconfig")
+                    sh(script: e2eCmd)
                 }
             }
         } finally {

--- a/vars/runTestK8sConformance.groovy
+++ b/vars/runTestK8sConformance.groovy
@@ -16,7 +16,7 @@ def call(Map parameters = [:]) {
     def e2eFocus = parameters.get('e2eFocus', null)
     def e2eSkip = parameters.get('e2eSkip', null)
     def sonobuoyImage = parameters.get('sonobuoyImage', 'gcr.io/heptio-images/sonobuoy')
-    def sonobuoyVersion = parameters.get('sonobuoyVersion', 'latest')
+    def sonobuoyVersion = parameters.get('sonobuoyVersion', 'v0.12.1')
     def e2eCmd = "./e2e-tests --kubeconfig ${WORKSPACE}/kubeconfig"
 
     if (e2eFocus != null) {


### PR DESCRIPTION
Add conformance test parameters for the Jenkins pipeline, so it's possible
to choose the sonobuoy repository as well as the container image version.

This allows us to easily choose what version we want to run specifically for
each branch.

(cherry picked from commit c8d23c0)

Backport of https://github.com/kubic-project/jenkins-library/pull/248