### PR TITLE
[3.0] Add support for retrieving supportconfig only on failure

### DIFF
--- a/vars/coreKubicProjectCi.groovy
+++ b/vars/coreKubicProjectCi.groovy
@@ -26,6 +26,9 @@ def call() {
     properties([
         buildDiscarder(logRotator(numToKeepStr: '15')),
         disableConcurrentBuilds(),
+        parameters([
+            booleanParam(name: 'RETRIEVE_SUPPORTCONFIG_ONLY_ON_FAILURE', defaultValue: false, description: 'Run supportconfig only if run failed?')
+        ])
     ])
 
     withKubicEnvironment(
@@ -35,7 +38,8 @@ def call() {
             gitBranch: env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME),
             gitCredentialsId: 'github-token',
             masterCount: 3,
-            workerCount: 2) {
+            workerCount: 2,
+            retrieveSupportconfigOnlyOnFailure: env.getEnvironment().get('RETRIEVE_SUPPORTCONFIG_ONLY_ON_FAILURE', (env.CHANGE_ID != null) ? 'true' : 'false').toBoolean()) {
 
         // Run the core project node tests
         coreKubicProjectNodeTests(


### PR DESCRIPTION
This is false by default, so all nightly jobs and in general all jobs will
retrieve the supportconfig always (success and failure runs), but for PR
testing it will be faster if we don't retrieve supportconfig for green runs,
giving faster feedback to the user.

(cherry picked from commit 1c1d691dc2f7761d7328295a7549d8294d78881e)

Backport of https://github.com/kubic-project/jenkins-library/pull/255