### PR TITLE
[3.0] vars: coreKubicProjectHousekeeping: Do not fail if not triggered by PR

### DIFF
--- a/vars/coreKubicProjectHousekeeping.groovy
+++ b/vars/coreKubicProjectHousekeeping.groovy
@@ -28,12 +28,12 @@ def call(Map parameters = [:]) {
 
     String changeTarget = env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME)
     boolean isBackport = changeTarget.matches(/release-\d\.\d/)
-    boolean hasBackportLabel = pullRequest.labels.contains("${changeTarget}-backport")
 
     stage('GitHub Labels') {
         // If this is a Pull Request build...
         if (env.CHANGE_ID) {
             echo "Add a backport label if needed"
+            boolean hasBackportLabel = pullRequest.labels.contains("${changeTarget}-backport")
             if (isBackport && !hasBackportLabel) {
                 echo "Adding backport label: ${changeTarget}-backport"
                 pullRequest.addLabels(["${changeTarget}-backport".toString()])


### PR DESCRIPTION
If the job is triggered via regular schedule instead of PR, the
pullRequest object does not exist and it fails as follows:

groovy.lang.MissingPropertyException: No such property: pullRequest for class: coreKubicProjectHousekeeping
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:53)
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.getProperty(ScriptBytecodeAdapter.java:458)
...

As such, only try to examine that object if we are trully running as
part of a PR.

(cherry picked from commit c80a5cc58ecdc87db545862fc361932f983de49c)

Backport of https://github.com/kubic-project/jenkins-library/pull/236