### PR TITLE
OpenStack: Simplify the stack name

### DIFF
--- a/vars/createEnvironmentOpenstack.groovy
+++ b/vars/createEnvironmentOpenstack.groovy
@@ -27,7 +27,7 @@ Environment call(Map parameters = [:]) {
     }
 
     Environment environment
-    String stackName = "${JOB_NAME}-${BUILD_NUMBER}".replace("/", "-")
+    String stackName = "${JOB_NAME}-${BUILD_NUMBER}".replace("/", "-").replace("caasp-nightly-openstack", "nightly")
 
     timeout(60) {
         if (deployment == 'terraform') {


### PR DESCRIPTION
The stack name was too long leading to failures with the CN field in
the certificates. As such, lets simplify the name a little bit.