### PR TITLE
Do not hardcode repository information in pipelines

### DIFF
--- a/vars/cloneAllKubicRepos.groovy
+++ b/vars/cloneAllKubicRepos.groovy
@@ -13,7 +13,6 @@
 // limitations under the License.
 // Clones all Kubic Repos.
 def call(Map parameters = [:]) {
-    def gitBase = parameters.get('gitBase')
     def branch = parameters.get('branch')
     def credentialsId = parameters.get('credentialsId')
     boolean ignorePullRequest = parameters.get('ignorePullRequest', false)
@@ -22,16 +21,16 @@ def call(Map parameters = [:]) {
 
     timeout(5) {
         parallel 'automation': {
-            cloneKubicRepo(gitBase: gitBase, branch: branch, credentialsId: credentialsId, ignorePullRequest: ignorePullRequest, repo: "automation")
+            cloneKubicRepo(branch: branch, credentialsId: credentialsId, ignorePullRequest: ignorePullRequest, repo: "automation")
         },
         'salt': {
-            cloneKubicRepo(gitBase: gitBase, branch: branch, credentialsId: credentialsId, ignorePullRequest: ignorePullRequest, repo: "salt")
+            cloneKubicRepo(branch: branch, credentialsId: credentialsId, ignorePullRequest: ignorePullRequest, repo: "salt")
         },
         'velum': {
-            cloneKubicRepo(gitBase: gitBase, branch: branch, credentialsId: credentialsId, ignorePullRequest: ignorePullRequest, repo: "velum")
+            cloneKubicRepo(branch: branch, credentialsId: credentialsId, ignorePullRequest: ignorePullRequest, repo: "velum")
         },
         'caasp-container-manifests': {
-            cloneKubicRepo(gitBase: gitBase, branch: branch, credentialsId: credentialsId, ignorePullRequest: ignorePullRequest, repo: "caasp-container-manifests")
+            cloneKubicRepo(branch: branch, credentialsId: credentialsId, ignorePullRequest: ignorePullRequest, repo: "caasp-container-manifests")
         }
     }
 }

--- a/vars/cloneKubicRepo.groovy
+++ b/vars/cloneKubicRepo.groovy
@@ -13,11 +13,11 @@
 // limitations under the License.
 // Clones a single Kubic Repo.
 def call(Map parameters = [:]) {
-    def gitBase = parameters.get('gitBase')
     def branch = parameters.get('branch')
     def credentialsId = parameters.get('credentialsId')
     boolean ignorePullRequest = parameters.get('ignorePullRequest', false)
     def repo = parameters.get('repo')
+    def gitBase = "https://" + getRepoInfo(repo)["hosting"] + "/" + getRepoInfo(repo)["organization"]
 
     echo "Cloning Kubic Repo: ${repo}"
 

--- a/vars/coreKubicProjectCi.groovy
+++ b/vars/coreKubicProjectCi.groovy
@@ -36,7 +36,6 @@ def call() {
             nodeLabel: 'leap15.0&&caasp-pr-worker',
             environmentType: 'caasp-kvm',
             environmentDestroy: env.getEnvironment().get('ENVIRONMENT_DESTROY', 'true').toBoolean(),
-            gitBase: 'https://github.com/kubic-project',
             gitBranch: env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME),
             gitCredentialsId: 'github-token',
             masterCount: 3,

--- a/vars/coreKubicProjectPeriodic.groovy
+++ b/vars/coreKubicProjectPeriodic.groovy
@@ -29,7 +29,6 @@ def call(Map parameters = [:], Closure preBootstrapBody = null, Closure body = n
                 environmentType: environmentType,
                 environmentTypeOptions: environmentTypeOptions,
                 environmentDestroy: environmentDestroy,
-                gitBase: 'https://github.com/kubic-project',
                 gitBranch: env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME),
                 gitCredentialsId: 'github-token',
                 masterCount: masterCount,

--- a/vars/getRepoInfo.groovy
+++ b/vars/getRepoInfo.groovy
@@ -1,0 +1,25 @@
+// Copyright 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+def call(String repository) {
+    // Definitive list of repositories
+    def Repositories = [
+        "automation": ["github.com", "kubic-project"],
+        "jenkins-library": ["github.com", "kubic-project"],
+        "salt": ["github.com", "kubic-project"],
+        "velum": ["github.com", "kubic-project"],
+        "caasp-container-manifests": ["github.com", "kubic-project"],
+    ]
+    return ["hosting": Repositories[repository][0], "organization": Repositories[repository][1]]
+}

--- a/vars/githubCollaboratorCheck.groovy
+++ b/vars/githubCollaboratorCheck.groovy
@@ -14,10 +14,16 @@
 def call(Map parameters = [:]) {
     echo "Starting GitHub Collaborator Check"
 
+    String hosting = getRepoInfo('repo')["hosting"]
     String org = parameters.get('org')
     String repo = parameters.get('repo')
     String user = parameters.get('user')
     String credentialsId = parameters.get('credentialsId')
+
+    if (hosting != "github.com") {
+        echo "The repository is not hosted on Github, Skipping check..."
+        return true;
+    }
 
     if (env.CHANGE_AUTHOR != null) {
         // Check if a change is from collaborator, or not.

--- a/vars/githubCollaboratorCheck.groovy
+++ b/vars/githubCollaboratorCheck.groovy
@@ -14,11 +14,11 @@
 def call(Map parameters = [:]) {
     echo "Starting GitHub Collaborator Check"
 
-    String hosting = getRepoInfo('repo')["hosting"]
     String org = parameters.get('org')
     String repo = parameters.get('repo')
     String user = parameters.get('user')
     String credentialsId = parameters.get('credentialsId')
+    String hosting = getRepoInfo(repo)["hosting"]
 
     if (hosting != "github.com") {
         echo "The repository is not hosted on Github, Skipping check..."

--- a/vars/withKubicEnvironment.groovy
+++ b/vars/withKubicEnvironment.groovy
@@ -19,7 +19,6 @@ def call(Map parameters = [:], Closure preBootstrapBody = null, Closure body) {
     def environmentTypeOptions = parameters.get('environmentTypeOptions', null)
     boolean environmentDestroy = parameters.get('environmentDestroy', true)
     boolean retrieveSupportconfigOnlyOnFailure = parameters.get('retrieveSupportconfigOnlyOnFailure', false)
-    def gitBase = parameters.get('gitBase', 'https://github.com/kubic-project')
     def gitBranch = parameters.get('gitBranch', env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME))
     def gitCredentialsId = parameters.get('gitCredentialsId', 'github-token')
     boolean gitIgnorePullRequest = parameters.get('gitIgnorePullRequest', false)
@@ -62,7 +61,7 @@ def call(Map parameters = [:], Closure preBootstrapBody = null, Closure body) {
 
         // Fetch the necessary code
         stage('Retrieve Code') {
-            cloneAllKubicRepos(gitBase: gitBase, branch: gitBranch, credentialsId: gitCredentialsId, ignorePullRequest: gitIgnorePullRequest)
+            cloneAllKubicRepos(branch: gitBranch, credentialsId: gitCredentialsId, ignorePullRequest: gitIgnorePullRequest)
         }
 
         // Fetch the necessary images


### PR DESCRIPTION
The pipelines assume that everything is hosted on Github. We should instead have a single place to reference all the repository information to make the code more flexible.