### PR TITLE
Jenkinsfile.codenarc: Use docker directly

### DIFF
--- a/Jenkinsfile.codenarc
+++ b/Jenkinsfile.codenarc
@@ -14,35 +14,19 @@ githubCollaboratorCheck(
     user: env.CHANGE_AUTHOR,
     credentialsId: 'github-token')
 
-def label = "salt-jenkins-library-${UUID.randomUUID().toString()}"
+node("leap15.0&&caasp-pr-worker") {
+    stage('Retrieve Code') {
+         checkout scm
+    }
 
-podTemplate(label: label, containers: [
-        containerTemplate(
-            name: 'codenarc',
-            image: 'registry.suse.de/devel/casp/ci/opensuse_leap_42.3_containers/jenkins-codenarc-container:latest',
-            alwaysPullImage: true,
-            ttyEnabled: true,
-            command: 'cat',
-            envVars: [
-                envVar(key: 'http_proxy', value: env.http_proxy),
-                envVar(key: 'https_proxy', value: env.http_proxy),
-            ],
-        ),
-]) {
-    node(label) {
-        stage('Retrieve Code') {
-            checkout scm
-        }
-
+    docker.image('registry.suse.de/devel/casp/ci/opensuse_leap_42.3_containers/jenkins-codenarc-container:latest').inside('-v ${WORKSPACE}:/codenarc') {
         stage('Style Checks') {
-            container('codenarc') {
-                try {
-                    sh 'java -classpath /groovy-all-2.4.6.jar:/CodeNarc-1.1.jar:/slf4j-api-1.7.25.jar:/slf4j-simple-1.7.25.jar org.codenarc.CodeNarc -report=html -report=xml'
-                } finally {
-                    archiveArtifacts(artifacts: "CodeNarcReport.html", fingerprint: true)
-                    archiveArtifacts(artifacts: "CodeNarcXmlReport.xml", fingerprint: true)
-                    warningsCodeNarc(filename: 'CodeNarcXmlReport.xml')
-                }
+            try {
+                sh(script: "java -classpath /groovy-all-2.4.6.jar:/CodeNarc-1.1.jar:/slf4j-api-1.7.25.jar:/slf4j-simple-1.7.25.jar org.codenarc.CodeNarc -report=html -report=xml -basedir=/codenarc")
+            } finally {
+                archiveArtifacts(artifacts: "CodeNarcReport.html", fingerprint: true)
+                archiveArtifacts(artifacts: "CodeNarcXmlReport.xml", fingerprint: true)
+                warningsCodeNarc(filename: 'CodeNarcXmlReport.xml')
             }
         }
     }


### PR DESCRIPTION
The k8s has been removed from Jenkins master so we should be using
docker directly on the worker.